### PR TITLE
feat: added auth provider credentials

### DIFF
--- a/next-auth-analysis/nextjs-next-auth-demo/next.config.js
+++ b/next-auth-analysis/nextjs-next-auth-demo/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    domains: ["lh3.googleusercontent.com"],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/next-auth-analysis/nextjs-next-auth-demo/src/app/api/auth/[...nextauth]/options.ts
+++ b/next-auth-analysis/nextjs-next-auth-demo/src/app/api/auth/[...nextauth]/options.ts
@@ -1,17 +1,37 @@
 import GoogleProvider from "next-auth/providers/google";
+import Credentials from "next-auth/providers/credentials";
 import { NextAuthConfig } from "next-auth";
+
+type AuthorizationInput = {
+  username?: string;
+  password?: string;
+};
 
 const authOptions: NextAuthConfig = {
   secret: process.env.NEXTAUTH_SECRET || Azion.env.get("NEXTAUTH_SECRET"),
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID || Azion.env.get("GOOGLE_CLIENT_ID"),
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET || Azion.env.get("GOOGLE_CLIENT_SECRET"),
+      clientId:
+        process.env.GOOGLE_CLIENT_ID || Azion.env.get("GOOGLE_CLIENT_ID"),
+      clientSecret:
+        process.env.GOOGLE_CLIENT_SECRET ||
+        Azion.env.get("GOOGLE_CLIENT_SECRET"),
+    }),
+    Credentials({
+      credentials: {
+        username: { label: "Username" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize({ username, password }, req) {
+        // get user from database e.g
+        // const user = await getUser(username, password);
+
+        return { name: "John Doe", email: username as string };
+      },
     }),
   ],
   callbacks: {
     signIn: ({ user }) => {
-      
       return true;
     },
     session: ({ session }) => {

--- a/next-auth-analysis/nextjs-next-auth-demo/src/app/page.tsx
+++ b/next-auth-analysis/nextjs-next-auth-demo/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
           height={37}
           priority
         />
-        <h1 className="text-xl">Next-Auth@^4.7.0 Analysis</h1>
+        <h1 className="text-xl">Next-Auth@^5.0.0-beta.17 Analysis</h1>
       </div>
       <div className="flex flex-col space-y-5 justify-center items-center">
         <div className="flex justify-center items-center min-w-28">

--- a/next-auth-analysis/nextjs-next-auth-demo/src/components/LogIn/index.tsx
+++ b/next-auth-analysis/nextjs-next-auth-demo/src/components/LogIn/index.tsx
@@ -2,6 +2,8 @@
 
 import { signOut, useSession } from "next-auth/react";
 import LogInGoogleButton from "../LogInGoogleButton";
+import LogInCredentials from "../LogInCredentialsButton";
+import Image from "next/image";
 
 const LogIn = () => {
   const { data: session, status } = useSession();
@@ -14,16 +16,42 @@ const LogIn = () => {
     <>
       {session?.user ? (
         <div>
-          <p>Signed in as {session?.user?.email}</p>
-          <div className="flex flex-row justify-center px-4 py-2 rounded bg-slate-200">
+          <div className="flex flex-col">
+            <h2 className="text-xl font-semibold text-white text-center py-3">
+              Welcome!
+            </h2>
+            <div className="flex items-center">
+              {session?.user?.image ? (
+                <Image
+                  className="rounded-full"
+                  src={session?.user?.image}
+                  alt="image profile"
+                  width={40}
+                  height={40}
+                />
+              ) : (
+                <div className="flex items-center justify-center rounded-full bg-slate-400 w-10 h-10">
+                  J
+                </div>
+              )}
+              <div className="flex flex-col">
+                <p className="ml-2">{session?.user?.name}</p>
+                <p className="ml-2 text-gray-400 text-xs">
+                  {session?.user?.email}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-row justify-center px-4 py-2 rounded bg-slate-200 mt-5">
             <button className="text-slate-700" onClick={() => signOut()}>
               Sign out
             </button>
           </div>
         </div>
       ) : (
-        <div>
+        <div className="space-y-1">
           <LogInGoogleButton />
+          <LogInCredentials />
         </div>
       )}
     </>

--- a/next-auth-analysis/nextjs-next-auth-demo/src/components/LogInCredentialsButton/index.tsx
+++ b/next-auth-analysis/nextjs-next-auth-demo/src/components/LogInCredentialsButton/index.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { FormEvent } from "react";
+
+const LogInCredentials = () => {
+  const handleSignIn = async (formData: FormEvent<HTMLFormElement>) => {
+    formData.preventDefault();
+    await signIn("credentials", {
+      username: formData.currentTarget.email.value,
+      password: formData.currentTarget.password.value,
+      redirect: true,
+    });
+  };
+
+  return (
+    <div className="w-[380px]">
+      <h2 className="text-xl font-semibold text-white text-center py-3">
+        With Credentials
+      </h2>
+      <form onSubmit={(formData) => handleSignIn(formData)}>
+        <div className="flex flex-col space-y-2">
+          <label className="text-base font-light text-white" htmlFor="email">
+            E-mail
+            <input
+              className="block flex-1 p-3 w-full font-normal rounded-md border text-zinc-800 border-gray-200 transition sm:text-sm placeholder:font-light placeholder:text-zinc-800 focus:border-zinc-500 focus:ring-zinc-500"
+              required
+              placeholder="email"
+              name="email"
+              type="email"
+            />
+          </label>
+          <label className="text-base font-light text-white" htmlFor="password">
+            Password
+            <input
+              className="block flex-1 p-3 w-full font-normal rounded-md border border-gray-200 transition sm:text-sm placeholder:font-light placeholder:text-zinc-800 focus:border-zinc-500 focus:ring-zinc-500 text-zinc-800"
+              required
+              placeholder="password"
+              name="password"
+              type="password"
+            />
+          </label>
+        </div>
+        <div className="flex justify-center rounded bg-slate-200 mt-4">
+          <button
+            className="flex flex-row w-full justify-center items-center px-4 py-2 text-slate-900 hover:bg-transparent hover:text-slate-600"
+            type="submit"
+          >
+            Sign in with Credentials
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default LogInCredentials;

--- a/next-auth-analysis/nextjs-next-auth-demo/src/components/LogInGoogleButton/index.tsx
+++ b/next-auth-analysis/nextjs-next-auth-demo/src/components/LogInGoogleButton/index.tsx
@@ -5,21 +5,26 @@ import Image from "next/image";
 
 const LogInGoogleButton = () => {
   return (
-    <div className="px-4 py-2 rounded bg-slate-200">
-      <button
-        className="flex flex-row items-center text-slate-900 hover:bg-transparent hover:text-slate-600"
-        onClick={() => signIn("google")}
-      >
-        <Image
-          className="mr-2"
-          src="https://authjs.dev/img/providers/google.svg"
-          alt="google"
-          width={20}
-          height={20}
-        ></Image>
-        Sign in with Google
-      </button>
-    </div>
+    <>
+      <h2 className="text-xl font-semibold text-white text-center py-3">
+        With Google
+      </h2>
+      <div className="flex flex-row justify-center rounded bg-slate-200">
+        <button
+          className="flex flex-row px-4 py-2 justify-center items-center text-slate-900 hover:bg-transparent hover:text-slate-600"
+          onClick={() => signIn("google")}
+        >
+          <Image
+            className="mr-2"
+            src="https://authjs.dev/img/providers/google.svg"
+            alt="google"
+            width={20}
+            height={20}
+          ></Image>
+          Sign in with Google
+        </button>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Adding a new auth provider: Credentials
With this provider, testing is easier, without the need to create the application in the Google Console.

`Clicking on SignIn With Google will display an error, but it will be successful on SigIn With Credentials.`

> If you want to create the application on Google, simply enter valid credentials.

Just configure the credentials this way.

```bash
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_SECRET=secret
GOOGLE_CLIENT_ID=test
GOOGLE_CLIENT_SECRET=test

```

<img width="873" alt="Screenshot 2024-05-23 at 16 45 41" src="https://github.com/aziontech/mm-js-packages-analysis/assets/22822098/aadc8be5-1aa1-4d0d-a85e-5477396d0051">